### PR TITLE
Add missed ostream header to fix the build error

### DIFF
--- a/core/proxy_map.h++
+++ b/core/proxy_map.h++
@@ -32,6 +32,7 @@
 #ifndef SKUI_CORE_PROXY_MAP_H
 #define SKUI_CORE_PROXY_MAP_H
 
+#include <ostream>
 #include <functional>
 #include <type_traits>
 


### PR DESCRIPTION
Background:

I ran across a build error on manjaro linux of latest version:

the compiler complains:

```shell
 std::ostream not found...
```