### PR TITLE
Fix GL Context Resource Busy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Introduction
 
+Fork from [skui-org/skui](https://github.com/skui-org/skui).
+Solve the OpenGL rendering problem and make it run properly on Windows.
+
 UI framework that uses [Skia](https://skia.org/) as a low-level drawing toolkit.
 It uses the newest features of the C++ Standard library (currently targetting C++17).
 

--- a/core/library_windows.c++
+++ b/core/library_windows.c++
@@ -56,9 +56,10 @@ namespace skui::core
       path directory = fs::absolute(filename).remove_filename();
       path filename_only = filename.filename();
 
-      std::array<path, 3> filenames{{directory / filename_only,
+      std::array<path, 4> filenames{{directory / filename_only,
                                      directory / (filename_only + dll_suffix),
-                                     directory / (dll_prefix + filename_only + dll_suffix)}};
+                                     directory / (dll_prefix + filename_only + dll_suffix),
+                                     filename_only}};
 
       for(const auto& filepath : filenames)
       {

--- a/gui/native_visual.h++
+++ b/gui/native_visual.h++
@@ -45,6 +45,7 @@ namespace skui::gui::native_visual
 
     virtual void create_surface(std::uintptr_t window) = 0;
     virtual void make_current() const = 0;
+    virtual void make_no_current() const = 0;
     virtual void swap_buffers(const graphics::pixel_size& size) const = 0;
 
     using gl_function_type = void(*)();

--- a/gui/native_visual/cgl.c++
+++ b/gui/native_visual/cgl.c++
@@ -49,6 +49,9 @@ namespace skui::gui::native_visual
   void cgl::make_current() const
   {}
 
+  void cgl::make_no_current() const
+  {}
+
   void cgl::swap_buffers(const graphics::pixel_size&) const
   {}
 

--- a/gui/native_visual/cgl.h++
+++ b/gui/native_visual/cgl.h++
@@ -42,6 +42,7 @@ namespace skui::gui::native_visual
 
     void create_surface(std::uintptr_t window) override;
     void make_current() const override;
+    void make_no_current() const override;
     void swap_buffers(const graphics::pixel_size&) const override;
 
     gl_get_function_type get_gl_function() const override;

--- a/gui/native_visual/coregraphics.c++
+++ b/gui/native_visual/coregraphics.c++
@@ -36,6 +36,9 @@ namespace skui::gui::native_visual
   void coregraphics::make_current() const
   {}
 
+  void coregraphics::make_no_current() const
+  {}
+
   void coregraphics::swap_buffers(const graphics::pixel_size&) const
   {}
 }

--- a/gui/native_visual/coregraphics.h++
+++ b/gui/native_visual/coregraphics.h++
@@ -42,6 +42,7 @@ namespace skui::gui::native_visual
 
     void create_surface(std::uintptr_t window) override;
     void make_current() const override;
+    void make_no_current() const override;
     void swap_buffers(const graphics::pixel_size&) const override;
   };
 }

--- a/gui/native_visual/egl.c++
+++ b/gui/native_visual/egl.c++
@@ -84,6 +84,11 @@ namespace skui::gui::native_visual
     eglMakeCurrent(egl_display, egl_surface, egl_surface, egl_context);
   }
 
+  void egl::make_current() const
+  {
+      eglMakeCurrent(egl_display, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
+  }
+
   void egl::swap_buffers(const graphics::pixel_size&) const
   {
     eglSwapBuffers(egl_display, egl_surface);

--- a/gui/native_visual/egl.h++
+++ b/gui/native_visual/egl.h++
@@ -44,6 +44,7 @@ namespace skui::gui::native_visual
 
     void create_surface(std::uintptr_t window) override;
     void make_current() const override;
+    void make_no_current() const override;
     void swap_buffers(const graphics::pixel_size&) const override;
 
     EGLint get_egl_visual();

--- a/gui/native_visual/glx.c++
+++ b/gui/native_visual/glx.c++
@@ -72,6 +72,11 @@ namespace skui::gui::native_visual
       core::debug_print("Call to glXMakeCurrent failed.\n");
   }
 
+  void glx::make_no_current() const
+  {
+    glXMakeCurrent(display, None, NULL)
+  }
+
   void glx::swap_buffers(const graphics::pixel_size&) const
   {
     glXSwapBuffers(display, drawable);

--- a/gui/native_visual/glx.h++
+++ b/gui/native_visual/glx.h++
@@ -51,6 +51,7 @@ namespace skui::gui::native_visual
 
     void create_surface(std::uintptr_t window) override;
     void make_current() const override;
+    void make_no_current() const override;
     void swap_buffers(const graphics::pixel_size&) const override;
 
     gl_get_function_type get_gl_function() const override;

--- a/gui/native_visual/wgl.c++
+++ b/gui/native_visual/wgl.c++
@@ -33,7 +33,7 @@ namespace skui::gui::native_visual
   {
     base::gl_function_type get_gl(void*, const char name[])
     {
-	  auto p = (base::gl_function_type)wglGetProcAddress(name);
+      auto p = (base::gl_function_type)wglGetProcAddress(name);
       if(p == 0 ||
          p == reinterpret_cast<base::gl_function_type>(0x1) ||
          p == reinterpret_cast<base::gl_function_type>(0x2) ||
@@ -74,7 +74,7 @@ namespace skui::gui::native_visual
       0,
       0,
       0, 0, 0, 0,
-      24,                        //Number of bits for the depthbuffer
+      24,                       //Number of bits for the depthbuffer
       8,                        //Number of bits for the stencilbuffer
       0,                        //Number of Aux buffers in the framebuffer.
       PFD_MAIN_PLANE,
@@ -105,7 +105,12 @@ namespace skui::gui::native_visual
   {
     BOOL success = wglMakeCurrent(device_context, gl_context);
     if(success == FALSE)
-      core::debug_print("Failed making WGL Context current.\n");
+      core::debug_print("Failed making WGL Context current. (", GetLastError(), ")\n");
+  }
+
+  void wgl::make_no_current() const
+  {
+    wglMakeCurrent(NULL, NULL);
   }
 
   base::gl_get_function_type wgl::get_gl_function() const

--- a/gui/native_visual/wgl.h++
+++ b/gui/native_visual/wgl.h++
@@ -49,6 +49,7 @@ namespace skui::gui::native_visual
     void create_surface(std::uintptr_t window) override;
     void swap_buffers(const graphics::pixel_size&) const override;
     void make_current() const override;
+    void make_no_current() const override;
 
     gl_get_function_type get_gl_function() const override;
 

--- a/gui/native_visual/win32.c++
+++ b/gui/native_visual/win32.c++
@@ -59,6 +59,11 @@ namespace skui::gui::native_visual
 
   }
 
+  void win32::make_no_current() const
+  {
+
+  }
+
   void win32::swap_buffers(const graphics::pixel_size& size) const
   {
     BITMAPINFO bitmap_info = create_bitmapinfo(size);

--- a/gui/native_visual/win32.h++
+++ b/gui/native_visual/win32.h++
@@ -52,6 +52,7 @@ namespace skui::gui::native_visual
 
     void create_surface(std::uintptr_t window) override;
     void make_current() const override;
+    void make_no_current() const override;
     void swap_buffers(const graphics::pixel_size& size) const override;
 
   private:

--- a/gui/native_visual/xcb.c++
+++ b/gui/native_visual/xcb.c++
@@ -89,6 +89,10 @@ namespace skui::gui::native_visual
   {
   }
 
+  void xcb::make_no_current() const
+  {
+  }
+
   void xcb::swap_buffers(const graphics::pixel_size& size) const
   {
     const std::uint16_t width = static_cast<std::uint16_t>(size.width);

--- a/gui/native_visual/xcb.h++
+++ b/gui/native_visual/xcb.h++
@@ -47,6 +47,7 @@ namespace skui::gui::native_visual
 
     void create_surface(std::uintptr_t window) override;
     void make_current() const override;
+    void make_no_current() const override;
     void swap_buffers(const graphics::pixel_size& size) const override;
 
     xcb_visualid_t visualid() const;

--- a/gui/window.c++
+++ b/gui/window.c++
@@ -207,6 +207,13 @@ namespace skui::gui
       // Ensure initialize_and_execute_platform_loop is waiting on handle_condition_variable
       std::unique_lock handle_lock{mutex};
     }
+
+    // Release context so that main thread to have right to access GL
+    {
+      const auto& native_visual = native_window->get_native_visual();
+      native_visual.make_no_current();
+    }
+
     initialized = true;
     handle_condition_variable.notify_all();
 


### PR DESCRIPTION
Add make no current to provide a chance to release context to avoid "resource busy" problem.
The render command thread occupies the window context for Skia Gr functions loading but it doesn't release context after Skia Gr interface initiated.
In this fork, I try to add a "make no current" feature to release the context to avoid resource busy problem.
This is useful for GPU multi-thread situation.